### PR TITLE
Adding painless-config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Redis client focused on providing a delightful user experience.
 ![Redie Screenshot](screenshot.png)
 
 # Usage
-Connect to your Redis server by passing the following command-line arguments (or setting their environment variable equivalents):
+Connect to your Redis server by passing the following command-line arguments 
+(or by using an `env.json` [painless-config](https://www.npmjs.com/package/painless-config) file, or setting their environment variable equivalents):
 ```
   -h      Hostname to connect to (defaults to 127.0.0.1 or REDIS_HOSTNAME environment variable)
   -p      Port to connect to (defaults to 6379 (non-TLS), 6380 (TLS), or REDIS_PORT environment variable)

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var redisCommands = require('redis-commands');
 var isJSON = require('is-json');
 var colorJSON = require('json-colorz');
 var package = require('./package.json');
+var painlessConfig = require('painless-config');
 
 var args = getArgs();
 var options = getOptions(args);
@@ -80,10 +81,10 @@ function getVersion() {
 
 function getArgs() {
   var cli = commandLineArgs([
-    { name: 'hostname', alias: 'h', type: String, defaultValue: process.env.REDIS_HOSTNAME || '127.0.0.1' },
-    { name: 'port', alias: 'p', type: Number, defaultValue: process.env.REDIS_PORT },
-    { name: 'password', alias: 'a', type: String, defaultValue: process.env.REDIS_PASSWORD },
-    { name: 'tls', type: Boolean, defaultValue: !!process.env.REDIS_TLS },
+    { name: 'hostname', alias: 'h', type: String, defaultValue: painlessConfig.get('REDIS_HOSTNAME') || '127.0.0.1' },
+    { name: 'port', alias: 'p', type: Number, defaultValue: painlessConfig.get('REDIS_PORT') },
+    { name: 'password', alias: 'a', type: String, defaultValue: painlessConfig.get('REDIS_PASSWORD') },
+    { name: 'tls', type: Boolean, defaultValue: !!painlessConfig.get('REDIS_TLS') },
     { name: 'version', alias: 'v', type: Boolean },
     { name: 'help', alias: '?', type: Boolean }
   ]);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "command-line-args": "^2.1.6",
     "is-json": "^2.0.0",
     "json-colorz": "^0.2.7",
+    "painless-config": "^0.1.0",
     "redis": "^2.6.0-0",
     "redis-commands": "^1.1.0"
   }


### PR DESCRIPTION
Adding support for `painless-config` will allow additional configuration resolution options; while still supporting the environment variable-based resolution for default values, this would support reading from an appropriate `env.json` file in the directory hierarchy.
